### PR TITLE
More fun

### DIFF
--- a/c/portfolio.css
+++ b/c/portfolio.css
@@ -18,7 +18,7 @@ html, body {
 }
 
 .subheading h2 {
-  font-size: 5.75em;
+  font-size: 3em;
   margin: 0;
   margin-bottom: -.3em;
 }
@@ -45,7 +45,7 @@ Source: https://paulund.co.uk/create-polaroid-image-with-css
 
 .pics__row div span:after {
   color: white;
-  font-size: 1.05em;
+  font-size: .85em;
   content: attr(title);
   position: relative;
   top: .5em;
@@ -62,7 +62,19 @@ Source: https://paulund.co.uk/create-polaroid-image-with-css
   border-bottom: 2px solid white;
 }
 
-/* SCREENS BIGGER THAN 768px (bigger than an mom's tablet) */
+/* SCREENS BIGGER THAN 568px (bigger than an iphone) */
+/* ≥ 568px */
+@media screen and (min-width: 35.5em) {
+  .subheading h2 {
+    font-size: 5.75em;
+  }
+
+  .pics__row div span:after {
+    font-size: 1.05em;
+  }
+}
+
+/* SCREENS BIGGER THAN 768px (bigger than mom's tablet) */
 /* ≥ 768px */
 @media screen and (min-width: 48em) {
 

--- a/c/portfolio.css
+++ b/c/portfolio.css
@@ -1,11 +1,11 @@
 
 html, body {
-	
+
     background-color: #0C2E38;
 }
 
 
-.pics-page .content {
+.portfolio-page .content {
   width: 80%;
   margin-left: 10%;
   margin-right: 10%;
@@ -100,5 +100,5 @@ Source: https://paulund.co.uk/create-polaroid-image-with-css
   .content .container {
     width: 45%;
   }
-  
+
 }

--- a/c/style.css
+++ b/c/style.css
@@ -15,6 +15,10 @@ body {
   text-align: center;
 }
 
+header {
+  position: inherit;
+}
+
 p, a, span {
   font-size: 1.4em;
   margin: 0;
@@ -125,7 +129,7 @@ animation: rainbow 6s ease infinite;
 /* name */
 .page-name {
   display: inline-block;
-  z-index: 2;
+  z-index: 10;
   cursor: default;
   width: 100%;
 
@@ -161,6 +165,7 @@ animation: rainbow 6s ease infinite;
 }
 
 .page-name--top:hover,
+.page-name--top:hover > *,
 .page-name--top:hover + .page-name--bottom {
   color: transparent;
   text-shadow: .04em .04em 0 #FFFFFF;
@@ -180,6 +185,10 @@ animation: rainbow 6s ease infinite;
 
 /* content */
 
+.content {
+  z-index: 0;
+}
+
 .content--block {
   margin-top: 12em;
 }
@@ -193,7 +202,7 @@ animation: rainbow 6s ease infinite;
 .content--show-on-hover {
   display: none;
   background-color: #D43B1D;
-  z-index: 1;
+  z-index: 5;
 }
 
 .page-name--top:hover ~ main .content--show-on-hover {

--- a/c/style.css
+++ b/c/style.css
@@ -80,16 +80,6 @@ animation: rainbow 6s ease infinite;
     100%{background-position:0% 82%}
 }
 
-.noselect {
-  -webkit-touch-callout: none; /* iOS Safari */
-    -webkit-user-select: none; /* Chrome/Safari/Opera */
-     -khtml-user-select: none; /* Konqueror */
-       -moz-user-select: none; /* Firefox */
-        -ms-user-select: none; /* Internet Explorer/Edge */
-            user-select: none; /* Non-prefixed version, currently
-                                  not supported by any browser */
-}
-
 /*
   Hide, but not for screenreaders
   Source: https://github.com/alphagov/govuk_elements/blob/0fcc6998aea888586d4c94a54a18c61390ae73a1/public/sass/elements/_helpers.scss#L25
@@ -231,6 +221,10 @@ footer a {
 .index-page {
   /* THE BACKGROUND COLOR OF THE HOME PAGE */
   background-color: #14647F;
+}
+
+.index-page .page-name--top:hover {
+  cursor: help;
 }
 
 .contact-page {

--- a/c/style.css
+++ b/c/style.css
@@ -55,7 +55,7 @@ a:focus {
 
 .centered {
   position: absolute;
-  top: 50%;
+  top: 49%;
   left: 50%;
   transform: translateX(-50%) translateY(-50%);
 }
@@ -144,7 +144,7 @@ animation: rainbow 6s ease infinite;
 
 .page-name--top {
   /* THE AMOUNT OF THE TOP WORD TO CUT OFF */
-  transform: translateY(-45%);
+  transform: translateY(-44%);
 }
 
 .page-name--top span,
@@ -153,7 +153,7 @@ animation: rainbow 6s ease infinite;
   left: 50%;
   top: 0;
   /* THE AMOUNT OF THE TOP WORD TO CUT OFF */
-  transform: translateX(-50%) translateY(-45%);
+  transform: translateX(-50%) translateY(-44%);
 }
 
 .page-name--top a {
@@ -175,7 +175,7 @@ animation: rainbow 6s ease infinite;
 
   left: 50%;
   /* translateY: THE AMOUNT OF THE BOTTOM WORD TO CUT OFF */
-  transform: translateX(-50%) translateY(38%);
+  transform: translateX(-50%) translateY(35%);
 }
 
 /* content */
@@ -204,7 +204,7 @@ animation: rainbow 6s ease infinite;
   margin: 0;
 }
 
-/* back to home link */
+/* footer link */
 
 footer {
   bottom: 0;

--- a/c/style.css
+++ b/c/style.css
@@ -190,7 +190,7 @@ animation: rainbow 6s ease infinite;
 }
 
 .content--block {
-  margin-top: 12em;
+  margin-top: 30vh;
 }
 
 .content--absolute {
@@ -261,6 +261,10 @@ footer a {
 @media screen and (min-width: 35.5em) {
   .page-name {
     font-size: 7em;
+  }
+
+  .content--block {
+    margin-top: 40vh;
   }
 
   .content .container {

--- a/c/style.css
+++ b/c/style.css
@@ -48,6 +48,26 @@ a:focus {
   position: relative;
 }
 
+/* PULSING BACKGROUND COLOUR */
+.pulse {
+background: linear-gradient(124deg, #FF0000, #D43B1D, #E81D1D, #E8B71D, #E3E81D, #1de840);
+background-size: 1800% 1800%;
+
+-webkit-animation: rainbow 6s ease infinite;
+animation: rainbow 6s ease infinite;
+}
+
+@-webkit-keyframes rainbow {
+    0%{background-position:0% 82%}
+    50%{background-position:100% 19%}
+    100%{background-position:0% 82%}
+}
+@keyframes rainbow {
+    0%{background-position:0% 82%}
+    50%{background-position:100% 19%}
+    100%{background-position:0% 82%}
+}
+
 .noselect {
   -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Chrome/Safari/Opera */
@@ -88,7 +108,6 @@ a:focus {
 /* name */
 
 .page-name {
-	
   z-index: 2;
   text-align: center;
   cursor: default;
@@ -105,14 +124,17 @@ a:focus {
   top: 0;
 
   /* THE AMOUNT OF THE TOP WORD TO CUT OFF */
-  transform: translateY(-50%);
+  transform: translateY(-45%);
+}
+.page-name--top:hover {
+  border: white 2px solid;
 }
 
 .page-name--bottom {
   bottom: 0;
 
   /* THE AMOUNT OF THE BOTTOM WORD TO CUT OFF */
-  transform: translateY(44%);
+  transform: translateY(38%);
 }
 
 .page-name:hover + .content--hover {
@@ -133,7 +155,7 @@ a:focus {
 
 .content--hover {
   display: none;
-  background-color: #3796B6;
+  background-color: #D43B1D;
   z-index: 1;
 }
 
@@ -224,3 +246,4 @@ footer a {
 /* SCREENS BIGGER THAN 1280px (really super high definition monitors) */
 /* 1280px */
 @media screen and (min-width: 80em) {}
+

--- a/c/style.css
+++ b/c/style.css
@@ -3,23 +3,28 @@
 * { box-sizing: border-box }
 
 html, body {
-    margin: 0;
-    height: 100%;
-    font-family: 'Source Code Pro', monospace;
-	/* default */
-    background-color: lightgrey;
-    color: white;
+  margin: 0;
+  height: 100%;
+  font-family: 'Source Code Pro', monospace;
+  /* default */
+  background-color: lightgrey;
+  color: white;
+}
+
+body {
+  text-align: center;
 }
 
 p, a {
   font-size: 1.4em;
+  margin: 0;
 }
 
 a {
   display: inline-block;
   width: 100%;
   text-decoration: none;
-  border: 2px solid transparent;
+  border: 3px solid transparent;
 
   /* THE COLOUR OF THE LINKS */
   color: white;
@@ -48,10 +53,17 @@ a:focus {
   position: relative;
 }
 
+.centered {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translateX(-50%) translateY(-50%);
+}
+
 /* PULSING BACKGROUND COLOUR */
 .pulse {
-background: linear-gradient(124deg, #FF0000, #D43B1D, #E81D1D, #E8B71D, #E3E81D, #1de840);
-background-size: 1800% 1800%;
+background: linear-gradient(124deg, #FF0000, #D43B1D, #E8B71D);
+background-size: 100% 1800%;
 
 -webkit-animation: rainbow 6s ease infinite;
 animation: rainbow 6s ease infinite;
@@ -93,52 +105,55 @@ animation: rainbow 6s ease infinite;
   border: 0;
 }
 
-/* page name + content */
+/* content + footer */
 
-.page-name, .content--full-width, footer {
+.content--full-width, footer {
   width: 100%;
   display: inline-block;
-  text-align: center;
 }
 
-.page-name, [class$="--absolute"] {
+[class*="--absolute"] {
   position: absolute;
 }
 
 /* name */
-
 .page-name {
+  display: inline-block;
   z-index: 2;
-  text-align: center;
   cursor: default;
 
   /* THE SIZE OF THE BIG PAGE TITLES */
   font-size: 6.5em;
   font-weight: 700;
+  line-height: 1;
 
   /* THE COLOUR OF THE BIG PAGE TITLES */
   color: #FFFFFF;
+  /* THE COLOUR OF THE TEXT SHADOW */
+  text-shadow: .03em .03em 0 hotpink;
 }
 
 .page-name--top {
-  top: 0;
-
   /* THE AMOUNT OF THE TOP WORD TO CUT OFF */
   transform: translateY(-45%);
 }
-.page-name--top:hover {
-  border: white 2px solid;
+
+.page-name--top:hover,
+.page-name--top:hover + .page-name--bottom {
+  color: transparent;
+  text-shadow: .03em .03em 0 #FFFFFF;
+  -webkit-text-fill-color: transparent; /* Will override color (regardless of order) */
+  -webkit-text-stroke-width: 3px;
+  -webkit-text-stroke-color: hotpink;
 }
 
 .page-name--bottom {
+  position: fixed;
   bottom: 0;
 
-  /* THE AMOUNT OF THE BOTTOM WORD TO CUT OFF */
-  transform: translateY(38%);
-}
-
-.page-name:hover + .content--hover {
-  display: inherit;
+  left: 50%;
+  /* translateY: THE AMOUNT OF THE BOTTOM WORD TO CUT OFF */
+  transform: translateX(-50%) translateY(38%);
 }
 
 /* content */
@@ -148,25 +163,23 @@ animation: rainbow 6s ease infinite;
 }
 
 .content--absolute {
-  position: absolute;
-  top: 48%;
-  transform: translateY(-50%);
+  top: 0;
+  left: 0;
+  height: 100vh;
 }
 
-.content--hover {
+.content--show-on-hover {
   display: none;
   background-color: #D43B1D;
   z-index: 1;
 }
 
-.content--hover p {
-  margin-top: 50em;
-  margin-bottom: 50em;
+.page-name--top:hover ~ main .content--show-on-hover {
+  display: inherit;
 }
 
-.content .container {
-  display: inline-block;
-  width: 90%;
+.content--show-on-hover p {
+  margin: 0;
 }
 
 /* back to home link */
@@ -219,7 +232,8 @@ footer a {
   }
 
   .content a {
-    width: 33%;
+    width: 31%;
+    margin: 0 1%;
   }
 }
 

--- a/c/style.css
+++ b/c/style.css
@@ -144,6 +144,8 @@ animation: rainbow 6s ease infinite;
   font-weight: 700;
   line-height: 1;
 
+  text-transform: uppercase;
+
   /* THE COLOUR OF THE BIG PAGE TITLES */
   color: #FFFFFF;
   /* THE COLOUR OF THE TEXT SHADOW */

--- a/c/style.css
+++ b/c/style.css
@@ -15,7 +15,7 @@ body {
   text-align: center;
 }
 
-p, a {
+p, a, span {
   font-size: 1.4em;
   margin: 0;
 }
@@ -105,6 +105,22 @@ animation: rainbow 6s ease infinite;
   border: 0;
 }
 
+.hover-container > .invisible-on-hover {
+  visibility: visible;
+}
+
+.hover-container:hover > .invisible-on-hover {
+  visibility: hidden;
+}
+
+.hover-container > .visible-on-hover {
+  visibility: hidden;
+}
+
+.hover-container:hover > .visible-on-hover {
+  visibility: visible;
+}
+
 /* content + footer */
 
 .content--full-width, footer {
@@ -121,16 +137,17 @@ animation: rainbow 6s ease infinite;
   display: inline-block;
   z-index: 2;
   cursor: default;
+  width: 100%;
 
   /* THE SIZE OF THE BIG PAGE TITLES */
-  font-size: 6.5em;
+  font-size: 4em;
   font-weight: 700;
   line-height: 1;
 
   /* THE COLOUR OF THE BIG PAGE TITLES */
   color: #FFFFFF;
   /* THE COLOUR OF THE TEXT SHADOW */
-  text-shadow: .03em .03em 0 hotpink;
+  text-shadow: .04em .04em 0 hotpink;
 }
 
 .page-name--top {
@@ -138,10 +155,23 @@ animation: rainbow 6s ease infinite;
   transform: translateY(-45%);
 }
 
+.page-name--top span,
+.page-name--top a {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  /* THE AMOUNT OF THE TOP WORD TO CUT OFF */
+  transform: translateX(-50%) translateY(-45%);
+}
+
+.page-name--top a {
+  border: none;
+}
+
 .page-name--top:hover,
 .page-name--top:hover + .page-name--bottom {
   color: transparent;
-  text-shadow: .03em .03em 0 #FFFFFF;
+  text-shadow: .04em .04em 0 #FFFFFF;
   -webkit-text-fill-color: transparent; /* Will override color (regardless of order) */
   -webkit-text-stroke-width: 3px;
   -webkit-text-stroke-color: hotpink;
@@ -186,6 +216,7 @@ animation: rainbow 6s ease infinite;
 
 footer {
   bottom: 0;
+  left: 0;
   padding-bottom: 2em;
 }
 
@@ -224,7 +255,7 @@ footer a {
 /* ≥ 568px */
 @media screen and (min-width: 35.5em) {
   .page-name {
-    font-size: 9em;
+    font-size: 7em;
   }
 
   .content .container {
@@ -241,7 +272,7 @@ footer a {
 /* ≥ 768px */
 @media screen and (min-width: 48em) {
   .page-name {
-    font-size: 12em;
+    font-size: 9em;
   }
 
   .content .container {
@@ -253,7 +284,7 @@ footer a {
 /* ≥ 1024px */
 @media screen and (min-width: 64em) {
   .page-name {
-    font-size: 14em;
+    font-size: 10em;
   }
 }
 

--- a/contact.html
+++ b/contact.html
@@ -5,9 +5,9 @@
   <!-- Basic Page Needs
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
   <meta charset="utf-8">
-  <title>CONTACT - JULIA CRAIG</title>
-  <meta name="description" content="CONTACT JULIA CRAIG">
-  <meta name="author" content="JULIA CRAIG">
+  <title>Contact - Julia Craig</title>
+  <meta name="description" content="Contact Julia Craig">
+  <meta name="author" content="Julia Craig">
 
   <!-- Mobile Specific Metas
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
@@ -30,8 +30,8 @@
 
     <header class="page-name page-name--top hover-container">
       <h1 class="visually-hidden">Contact</h1>
-      <span class="invisible-on-hover">CONTACT</span>
-      <a class="visible-on-hover link__back" href="index.html">&larr;&nbsp;BACK</a>
+      <span class="invisible-on-hover">Contact</span>
+      <a class="visible-on-hover link__back" href="index.html">&larr;&nbsp;Back</a>
     </header>
 
     <div class="content content--absolute content--full-width">

--- a/contact.html
+++ b/contact.html
@@ -27,9 +27,12 @@
 
 </head>
 <body class="contact-page position-relative overflow-hidden">
-    <h1 class="visually-hidden">Contact</h1>
 
-    <span class="page-name page-name--top noselect">CONTACT</span>
+    <header class="page-name page-name--top hover-container">
+      <h1 class="visually-hidden">Contact</h1>
+      <span class="invisible-on-hover">CONTACT</span>
+      <a class="visible-on-hover link__back" href="index.html">&larr;&nbsp;BACK</a>
+    </header>
 
     <div class="content content--absolute content--full-width">
       <div class="container centered">
@@ -43,7 +46,7 @@
     </div><!-- end of .content -->
 
     <footer class="footer--absolute">
-      <a href="index.html" class="link__back">&larr; back</a>
+      <a href="index.html" class="link__back">&larr;&nbsp;back</a>
     </footer>
 <!-- End Document
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->

--- a/contact.html
+++ b/contact.html
@@ -32,7 +32,7 @@
     <span class="page-name page-name--top noselect">CONTACT</span>
 
     <div class="content content--absolute content--full-width">
-      <div class="container">
+      <div class="container centered">
         <a href="mailto:juliacraig3@cmail.carleton.ca" class="link__email" title="pls no spam" target="_blank">email</a><!--
 
         --><a href="https://twitter.com/JayCraig1101" class="link__twitter" title="pls follow me" target="_blank">twitter</a><!--

--- a/index.html
+++ b/index.html
@@ -27,11 +27,15 @@
 
 </head>
 <body class="index-page position-relative overflow-hidden">
-  <header>
+  <header class="page-name page-name--top">
     <h1 class="visually-hidden">Julia Craig</h1>
+    <span>JULIA</span>
   </header>
-  <span class="page-name page-name--top noselect">JULIA</span>
-  <span class="page-name page-name--bottom noselect">CRAIG</span>
+
+  <span class="page-name page-name--bottom">
+    <span>CRAIG</span>
+  </span>
+
   <main role="main">
     <div class="content pulse content--show-on-hover content--absolute content--full-width">
       <p class="centered">My name is Julia and I am a <em>genius</em>.</p>

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
   <!-- Basic Page Needs
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
   <meta charset="utf-8">
-  <title>JULIA CRAIG</title>
-  <meta name="description" content="JULIA CRAIG">
-  <meta name="author" content="JULIA CRAIG">
+  <title>Julia Craig dot CA</title>
+  <meta name="description" content="Homepage of Julia Craig">
+  <meta name="author" content="Julia Craig">
 
   <!-- Mobile Specific Metas
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
@@ -29,11 +29,11 @@
 <body class="index-page position-relative overflow-hidden">
   <header class="page-name page-name--top">
     <h1 class="visually-hidden">Julia Craig</h1>
-    <span>JULIA</span>
+    <span>Julia</span>
   </header>
 
   <span class="page-name page-name--bottom">
-    <span>CRAIG</span>
+    <span>Craig</span>
   </span>
 
   <main role="main">

--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
 
     <span class="page-name page-name--top noselect">JULIA</span>
 
-    <div class="content content--hover content--absolute content--full-width">
-      <p>My name is Julia and I am a <em>genius</em>.</p>
+    <div class="content pulse content--hover content--absolute content--full-width">
+      <p class="anim-text-flow">My name is Julia and I am a <em>genius</em>.</p>
     </div>
 
     <div class="content content--absolute content--full-width">

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
     <div class="content content--absolute content--full-width">
       <div class="container centered">
         <!-- focus styles please! -->
-        <a href="pics.html" class="link__pics" title="so amaze">portfolio</a><!--
+        <a href="portfolio.html" class="link__pics" title="so amaze">portfolio</a><!--
         --><a href="contact.html" class="link__contact" title="get @ me">contact</a>
       </div>
     </div><!-- end of .contact -->

--- a/index.html
+++ b/index.html
@@ -27,24 +27,24 @@
 
 </head>
 <body class="index-page position-relative overflow-hidden">
+  <header>
     <h1 class="visually-hidden">Julia Craig</h1>
-
-    <span class="page-name page-name--top noselect">JULIA</span>
-
-    <div class="content pulse content--hover content--absolute content--full-width">
-      <p class="anim-text-flow">My name is Julia and I am a <em>genius</em>.</p>
+  </header>
+  <span class="page-name page-name--top noselect">JULIA</span>
+  <span class="page-name page-name--bottom noselect">CRAIG</span>
+  <main role="main">
+    <div class="content pulse content--show-on-hover content--absolute content--full-width">
+      <p class="centered">My name is Julia and I am a <em>genius</em>.</p>
     </div>
 
     <div class="content content--absolute content--full-width">
-      <div class="container">
+      <div class="container centered">
         <!-- focus styles please! -->
         <a href="pics.html" class="link__pics" title="so amaze">portfolio</a><!--
         --><a href="contact.html" class="link__contact" title="get @ me">contact</a>
       </div>
     </div><!-- end of .contact -->
-
-
-    <span class="page-name page-name--bottom noselect">CRAIG</span>
+  </main>
 
 <!-- End Document
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->

--- a/pics.html
+++ b/pics.html
@@ -30,9 +30,12 @@
 
 </head>
 <body class="pics-page position-relative">
-    <h1 class="visually-hidden">Pictures</h1>
 
-    <span class="page-name page-name--top noselect">PORTFOLIO</span>
+    <header class="page-name page-name--top hover-container">
+      <h1 class="visually-hidden">Portfolio</h1>
+      <span class="invisible-on-hover">PORTFOLIO</span>
+      <a class="visible-on-hover link__back" href="index.html">&larr;&nbsp;BACK</a>
+    </header>
 
     <div class="content content--full-width content--block">
 	<!-- 2016 - Present -->
@@ -177,7 +180,7 @@
     </div><!-- end of .content -->
 
     <footer>
-      <a href="index.html" class="link__back">&larr; back</a>
+      <a href="index.html" class="link__back">&larr;&nbsp;back</a>
     </footer>
 <!-- End Document
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->

--- a/pics.html
+++ b/pics.html
@@ -78,7 +78,7 @@
 
           <div class="pure-u-1 pure-u-md-1-3">
             <span title="Batman">
-              <img class="pure-img" src="i/batman.JPG" alt="Batman"> 
+              <img class="pure-img" src="i/batman.JPG" alt="Batman">
             </span>
           </div>
 
@@ -93,9 +93,9 @@
               <img class="pure-img" src="i/iron.JPG" alt="Iron Man">
             </span>
           </div>
-		
+
 		</div><!-- end of pure-g (end of the row)-->
-		
+
 		 <!-- second row of images -->
         <div class="pure-g pics__row">
 
@@ -128,12 +128,12 @@
 
         <!-- first row of images -->
         <div class="pure-g pics__row">
-		
+
           <div class="pure-u-1 pure-u-md-1-3">
             <span title="Leonardo Dicaprio">
               <img class="pure-img" src="i/leo.JPG" alt="Leonardo Dicaprio">
             </span>
-          </div>		
+          </div>
 
           <div class="pure-u-1 pure-u-md-1-3">
             <span title="Hear me roar">
@@ -175,7 +175,7 @@
 	  </div><!-- end of year (Black and White)-->
 
     </div><!-- end of .content -->
-		
+
     <footer>
       <a href="index.html" class="link__back">&larr; back</a>
     </footer>

--- a/portfolio.html
+++ b/portfolio.html
@@ -22,14 +22,14 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/g/pure@0.6.2(base-min.css+grids-min.css+grids-responsive-min.css)">
 
   <link rel="stylesheet" href="c/style.css">
-  <link rel="stylesheet" href="c/pics.css">
+  <link rel="stylesheet" href="c/portfolio.css">
 
   <!-- Favicon
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
   <!--link rel="icon" type="image/png" href="i/favicon.png"-->
 
 </head>
-<body class="pics-page position-relative">
+<body class="portfolio-page position-relative">
 
     <header class="page-name page-name--top hover-container">
       <h1 class="visually-hidden">Portfolio</h1>

--- a/portfolio.html
+++ b/portfolio.html
@@ -5,9 +5,9 @@
   <!-- Basic Page Needs
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
   <meta charset="utf-8">
-  <title>PORTFOLIO - JULIA CRAIG</title>
-  <meta name="description" content="PORTFOLIO BY JULIA CRAIG">
-  <meta name="author" content="JULIA CRAIG">
+  <title>Portfolio - Julia Craig</title>
+  <meta name="description" content="Portfolio of Julia Craig">
+  <meta name="author" content="Julia Craig">
 
   <!-- Mobile Specific Metas
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
@@ -33,8 +33,8 @@
 
     <header class="page-name page-name--top hover-container">
       <h1 class="visually-hidden">Portfolio</h1>
-      <span class="invisible-on-hover">PORTFOLIO</span>
-      <a class="visible-on-hover link__back" href="index.html">&larr;&nbsp;BACK</a>
+      <span class="invisible-on-hover">Portfolio</span>
+      <a class="visible-on-hover link__back" href="index.html">&larr;&nbsp;Back</a>
     </header>
 
     <div class="content content--full-width content--block">


### PR DESCRIPTION
This pull request makes a larger changes and a few smaller changes.

It's not the end result, but it's [forward motion](https://www.youtube.com/watch?v=dOgB4aaZhZM). The important thing is that we can change things after they go in.

The theme of this pull request is 🎉  fun 🎈 

## 1. More fun page titles

Page titles are both more visible (means they're more legible), and they have a funky background colour. Win win.

| before | after |
|--------|-------|
| ![screen shot 2017-08-15 at 18 22 49](https://user-images.githubusercontent.com/2454380/29327452-0f9a0284-81e7-11e7-8ebb-eb28b4024e7a.png)  |  ![screen shot 2017-08-15 at 18 22 44](https://user-images.githubusercontent.com/2454380/29327461-1acdb650-81e7-11e7-9697-e7f55cb559da.png)   |

## 2. More fun hover effect

Previous hover effect was lame in that it was boring and bad because it was low-contrast and hard to know how to trigger it. More here: https://github.com/juliacraig/juliacraig.github.io/issues/3

New hover effect is way better:
- cool outline text effect for page title
- dramatic colour shift
  - colour is also pulsating which is super cool (looks way better in a browser than that gif)
- icon changes to a new icon (maybe not the best one but at least it does something)
- hover area has been reigned in to be mostly just the area around the text. it's still not very knowable but it's more intuitive.

| before | after |
|--------|-------|
| ![hover 1](https://user-images.githubusercontent.com/2454380/29280348-ca3efbb0-8112-11e7-959b-fd134c81c46f.gif)  |  ![hover 2](https://user-images.githubusercontent.com/2454380/29327624-b24ec53c-81e7-11e7-83d9-92e22634a555.gif) |

known problems are still that you probably won't be able to see it on mobile and that it's not really obvious that you can do it (but those aren't new problems).


## 3. More fun navigation

Getting back to the home page was only possible through the link at the bottom. [This is clearly suboptimal](https://github.com/juliacraig/juliacraig.github.io/issues/5), especially for long pages.  New idea is that hovering over the page title turns into a "back" link.  It's also a pretty hidden feature but it at least follows the convention that somewhere in the header you can click something to take you home. 

Known problem is that you won't be able to discover this on mobile.

| before | after |
|--------|-------|
| <pre>Before there was nothing</pre> |  ![contact](https://user-images.githubusercontent.com/2454380/29327819-5eea2cfa-81e8-11e7-9ab5-6f66e12445d6.gif) |

## 4. Smaller page titles on mobile

[The text on the portfolio page is mostly too big](https://github.com/juliacraig/juliacraig.github.io/issues/2). This isn't a "fun" change so much as it's a needed one.  I haven't thought this out a lot or tested it loads but as a quick patch it's definitely an improvement so probably worth getting in.

| before | after |
|--------|-------|
| ![screen shot 2017-08-15 at 18 42 07](https://user-images.githubusercontent.com/2454380/29328158-7c7f952e-81e9-11e7-8182-3c42ac7706d2.png) |  ![screen shot 2017-08-15 at 18 15 48](https://user-images.githubusercontent.com/2454380/29328163-80a1e4a4-81e9-11e7-826c-37868a7c5461.png) |

## Misc.

A few other things:

- cleaned up some of the HTML
- the left arrow and word "back" would separate on mobile. Now they stay together.
- made the link borders a bit bigger. this is to match the line stroke of the letter outlines when you hover over a page title
- removed most of the capital letters in the page tab
- changed everything that said "pics" to "portfolio" because that's the current name of the page
